### PR TITLE
fixed rbac tests & fetches to be objects

### DIFF
--- a/packages/sdk/src/modules/rbac/index.ts
+++ b/packages/sdk/src/modules/rbac/index.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4, v4 } from 'uuid';
-import { CreateStorageKeysEnum, FetchRoles } from '../../types';
+import { CreateStorageKeysEnum } from '../../types';
 import { Base } from '../base';
 import { ApiPromise } from '@polkadot/api';
 import { createStorageKeys } from '../../utils';
@@ -102,6 +102,18 @@ interface FetchPermission {
 interface FetchRole {
   owner: Address;
   roleId: string;
+}
+
+interface FetchGroups {
+  owner: Address;
+}
+
+interface FetchPermissions {
+  owner: Address;
+}
+
+interface FetchRoles {
+  owner: Address;
 }
 
 interface FetchRolePermissions {
@@ -517,35 +529,26 @@ export class RBAC extends Base {
 
   /**
    * Fetch all roles.
-   * @param ownerAddress - The ownerAddress is public address of user or owner who created a roles.
+   * @param options - The ownerAddress is public address of user or owner who created a roles.
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRoles(ownerAddress: Address): Promise<FetchRoles[]> {
+  public async fetchRoles(options: FetchRoles): Promise<ResponseFetchGroup[]> {
     try {
-      if (!ownerAddress) throw new Error('Invalid owner address');
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
       const api = this._getApi();
       const roles = (await api.query?.['peaqRbac']?.['roleStore'](
-        ownerAddress
+        owner
       )) as unknown as Entity[];
       if (!roles) {
         throw new Error(
-          `Roles not exits with this owner address = ${ownerAddress}`
+          `Roles not exits with this owner address = ${owner}`
         );
       }
-      const responseData: FetchRoles[] = [];
-      roles.forEach((item, index) => {
-        const readAbleData = item.toHuman();
-        const stringFyData = JSON.stringify(readAbleData);
-        const parseData = JSON.parse(stringFyData);
-        const { id, name, enabled } = parseData;
-        let payload = {
-          id,
-          name,
-          enabled,
-        };
-        responseData.push(payload);
-      });
+      const responseData: ResponseFetchGroup[] = roles?.map(
+        (item) => JSON.parse(JSON.stringify(item.toHuman()))
+      );
       return responseData;
     } catch (error) {
       throw new Error(`Error occurred while fetching roles: ${error}`);
@@ -611,7 +614,7 @@ export class RBAC extends Base {
     try {
       const { groupId, owner } = option;
       this._validateInput(groupId);
-      const api = await this._getApi();
+      const api = this._getApi();
       const { hashed_key: role2GroupStoreKey } = createStorageKeys([
         {
           value: owner,
@@ -699,12 +702,14 @@ export class RBAC extends Base {
 
   /**
    * Fetch all groups.
-   * @param option - The option for fetch groups.
+   * @param options - The option for fetch groups.
    * @returns A promise that resolves when the groups is fetched.
    */
 
-  public async fetchGroups(owner: Address): Promise<FetchRoles[]> {
+  public async fetchGroups(options: FetchGroups): Promise<ResponseFetchGroup[]> {
     try {
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
       const api = this._getApi();
       const groups = (await api.query?.['peaqRbac']?.['groupStore'](
         owner
@@ -712,7 +717,7 @@ export class RBAC extends Base {
       if (!groups) {
         throw new Error(`No group is found of owner: ${owner}`);
       }
-      const responseData: FetchRoles[] = groups?.map((item) =>
+      const responseData: ResponseFetchGroup[] = groups?.map((item) =>
         JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -766,22 +771,24 @@ export class RBAC extends Base {
 
   /**
    * Fetch all permissions.
-   * @param option - The option for fetch permissions.
+   * @param options - The option for fetch permissions.
    * @returns A promise that resolves when the permissions is fetched.
    */
 
-  public async fetchPermissions(owner: Address): Promise<ResponseFetchGroup[]> {
+  public async fetchPermissions(options: FetchPermissions): Promise<ResponseFetchGroup[]> {
     try {
-      const api = await this._getApi();
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
+      const api = this._getApi();
       const permissions = (await api.query?.['peaqRbac']?.['permissionStore'](
         owner
       )) as unknown as Entity[];
-      const responseData: FetchRoles[] = permissions?.map((item) =>
-        JSON.parse(JSON.stringify(item.toHuman()))
-      );
       if (!permissions) {
         throw new Error(`No permission is found of owner: ${owner}`);
       }
+      const responseData: ResponseFetchGroup[] = permissions?.map((item) =>
+        JSON.parse(JSON.stringify(item.toHuman()))
+      );
       return responseData;
     } catch (error) {
       throw new Error(`Error occurred while fetching permissions: ${error}`);
@@ -794,11 +801,11 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRole(option: FetchRole): Promise<FetchRoles | undefined> {
+  public async fetchRole(option: FetchRole): Promise<ResponseFetchGroup | undefined> {
     try {
       const { owner, roleId } = option;
       this._validateInput(roleId);
-      const api = await this._getApi();
+      const api = this._getApi();
       const { hashed_key } = createStorageKeys([
         {
           value: owner,

--- a/packages/sdk/src/modules/rbac/index.ts
+++ b/packages/sdk/src/modules/rbac/index.ts
@@ -7,8 +7,9 @@ import { stringToU8a } from '@polkadot/util';
 import type {
   SDKMetadata,
   Address,
+  ResponseFetchRole,
   ResponseFetchGroup,
-  ResponsePermission,
+  ResponseFetchPermission,
   ResponseFetchUserGroups,
   ResponseRole2User,
   ResponseRole2Group,
@@ -533,7 +534,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRoles(options: FetchRoles): Promise<ResponseFetchGroup[]> {
+  public async fetchRoles(options: FetchRoles): Promise<ResponseFetchRole[]> {
     try {
       const { owner } = options;
       if (!owner) throw new Error('Invalid owner address');
@@ -546,7 +547,7 @@ export class RBAC extends Base {
           `Roles not exits with this owner address = ${owner}`
         );
       }
-      const responseData: ResponseFetchGroup[] = roles?.map(
+      const responseData: ResponseFetchRole[] = roles?.map(
         (item) => JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -847,7 +848,7 @@ export class RBAC extends Base {
 
   public async fetchRolePermissions(
     option: FetchRolePermissions
-  ): Promise<ResponsePermission[]> {
+  ): Promise<ResponseFetchPermission[]> {
     try {
       const { owner, roleId } = option;
       this._validateInput(roleId);
@@ -871,7 +872,7 @@ export class RBAC extends Base {
       ](hashed_key)) as unknown as Permission2Role[];
       if (!rolePermissions)
         throw new Error(`Permission not exits with this roleId = ${roleId}`);
-      const responeRolePermission: ResponsePermission[] = rolePermissions?.map(
+      const responeRolePermission: ResponseFetchPermission[] = rolePermissions?.map(
         (item) => JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responeRolePermission;

--- a/packages/sdk/src/modules/rbac/rbac.spec.ts
+++ b/packages/sdk/src/modules/rbac/rbac.spec.ts
@@ -4,7 +4,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { unsubscribeRuntimeVersion } from '../../utils';
 import { RBAC } from './index';
 
-const BASE_URL = "wss://wsspc1-qa.agung.peaq.network"; //process.env['NX_NETWORK_BASE_URL'] as string;
+const BASE_URL = process.env['NX_NETWORK_BASE_URL'] as string;
 
 describe('RBAC', () => {
   let api: ApiPromise;

--- a/packages/sdk/src/modules/rbac/rbac.spec.ts
+++ b/packages/sdk/src/modules/rbac/rbac.spec.ts
@@ -4,7 +4,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { unsubscribeRuntimeVersion } from '../../utils';
 import { RBAC } from './index';
 
-const BASE_URL = process.env['NX_NETWORK_BASE_URL'] as string;
+const BASE_URL = "wss://wsspc1-qa.agung.peaq.network"; //process.env['NX_NETWORK_BASE_URL'] as string;
 
 describe('RBAC', () => {
   let api: ApiPromise;
@@ -34,17 +34,18 @@ describe('RBAC', () => {
         address: alice.address,
       });
       expect(typeof result.roleId).toBe('string');
-    });
+    }, 30000);
 
     it('should create a new role with coustom id ID', async () => {
       const name = 'test-1-create-coustom-roleID-rohan-ye';
       const result = await rbac.createRole({
         roleName: name,
         address: alice.address,
-        roleId: 'bcmnxbncvbnxvcnbvxnbcvnxbvchvchvxchgvchgvxcnbv',
+        roleId: 'bcmnxbncvbnxvcnbvxnbcvnxbvchvchv',
       });
+      expect(result.roleId).toBe('bcmnxbncvbnxvcnbvxnbcvnxbvchvchv');
       expect(typeof result.roleId).toBe('string');
-    });
+    }, 30000);
 
     it('should throw an error if name is not provided', async () => {
       await expect(
@@ -68,18 +69,18 @@ describe('RBAC', () => {
       });
       expect(typeof result.message).toBe('string');
       expect(result.message).toContain('Successfully disable role');
-    }, 30000);
+    }, 30500);
   });
 
-  describe('fetchRoles()', () => {
+  describe('fetch Roles, groups, and permissions', () => {
     it('should throw an error when owner address is not provided', async () => {
-      await expect(rbac.fetchRoles('')).rejects.toThrow(
+      await expect(rbac.fetchRoles({owner: ''})).rejects.toThrow(
         'Invalid owner address'
       );
     });
 
     it('should fetch roles', async () => {
-      const response = await rbac.fetchRoles(alice.address);
+      const response = await rbac.fetchRoles({owner: alice.address});
       expect(typeof response).toBe('object');
       if (response.length > 0) {
         expect(typeof response[0].id).toBe('string');
@@ -87,6 +88,25 @@ describe('RBAC', () => {
         expect(typeof response[0].enabled).toBe('boolean');
       }
     });
+    it('should fetch groups', async () => {
+      const response = await rbac.fetchGroups({owner: alice.address});
+      expect(typeof response).toBe('object');
+      if (response.length > 0) {
+        expect(typeof response[0].id).toBe('string');
+        expect(typeof response[0].name).toBe('string');
+        expect(typeof response[0].enabled).toBe('boolean');
+      }
+    });
+    it('should fetch permissions', async () => {
+      const response = await rbac.fetchPermissions({owner: alice.address});
+      expect(typeof response).toBe('object');
+      if (response.length > 0) {
+        expect(typeof response[0].id).toBe('string');
+        expect(typeof response[0].name).toBe('string');
+        expect(typeof response[0].enabled).toBe('boolean');
+      }
+    });
+  });
     describe(' Group ', () => {
       it('create new group', async () => {
         const name = 'rohan-group';
@@ -110,11 +130,14 @@ describe('RBAC', () => {
 
       it('fetch group permission()', async () => {
         const response = await rbac.fetchGroupPermissions({
-          groupId: groupId,
           owner: alice.address,
+          groupId: '5bff002a-926d-4e08-88d5-1e7304a2'          
         });
+        expect(typeof response).toBe('object');
+        expect(typeof response[0].id).toBe('string');
+        expect(typeof response[0].name).toBe('string');
+        expect(typeof response[0].enabled).toBe('boolean');
       });
-
       it('fetch group roles()', async () => {
         const response = await rbac.fetchGroupRoles({
           groupId: groupId,
@@ -131,13 +154,14 @@ describe('RBAC', () => {
         expect(result.message).toContain('Successfully assign role');
       }, 30000);
       it('assign user to group', async () => {
+
         const result = await rbac.assignUserToGroup({
           groupId: '5bff002a-926d-4e08-88d5-1e7304a2',
-          userId: alice.address,
+          userId: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHp',
         });
         expect(typeof result.message).toBe('string');
         expect(result.message).toContain('Successfully assign user');
-      }, 30000);
+      }, 30500);
 
       it('disable group', async () => {
         const result = await rbac.disableGroup({
@@ -238,4 +262,3 @@ describe('RBAC', () => {
       }, 30000);
     });
   });
-});

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -74,13 +74,19 @@ export interface SignTransction{
 }
 
 
+export interface ResponseFetchRole{
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
 export interface ResponseFetchGroup{
   id: string;
   name: string;
   enabled: boolean;
 }
 
-export interface ResponsePermission{
+export interface ResponseFetchPermission{
   permission: string,
   role: string
 }

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -73,11 +73,6 @@ export interface SignTransction{
   statusCallback?: (result: ISubmittableResult) => void;
 }
 
-export interface FetchRoles{
-  id: string;
-  name: string;
-  enabled: boolean;
-}
 
 export interface ResponseFetchGroup{
   id: string;


### PR DESCRIPTION
Some of the rbac tests weren't working, and they have been fixed.

In the fetchRoles, fetchGroups, and fetchPermission we were passing an Address type. It have been changed to pass an interface containing an Address so that we can use the same syntax {} when calling the functions.