### PR TITLE
chores(readme): Fix typo - documnetion -> documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # peaq-js
 
-Follow [documnetion](https://docs.peaq.network/sdk) for detailed overveiw of feature and functionalites of peaq SDK.
+Follow [documentation](https://docs.peaq.network/sdk) for detailed overveiw of feature and functionalites of peaq SDK.


### PR DESCRIPTION
Fixed a typo in the README file. "documnetion" was incorrectly used instead of "documentation"