### PR TITLE
fix: fetch all for roles, permissions, and groups

### DIFF
--- a/packages/sdk/src/modules/rbac/index.ts
+++ b/packages/sdk/src/modules/rbac/index.ts
@@ -7,7 +7,7 @@ import { stringToU8a } from '@polkadot/util';
 import type {
   SDKMetadata,
   Address,
-  ResponseFetchGroup,
+  FetchResponseData,
   ResponsePermission,
   ResponseFetchUserGroups,
   ResponseRole2User,
@@ -533,7 +533,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRoles(options: FetchRoles): Promise<ResponseFetchGroup[]> {
+  public async fetchRoles(options: FetchRoles): Promise<FetchResponseData[]> {
     try {
       const { owner } = options;
       if (!owner) throw new Error('Invalid owner address');
@@ -548,7 +548,7 @@ export class RBAC extends Base {
           `Roles not exits with this owner address = ${owner}`
         );
       }
-      const responseData: ResponseFetchGroup[] = roles?.map(
+      const responseData: FetchResponseData[] = roles?.map(
         (item) => JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -563,7 +563,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the group is fetched.
    */
 
-  public async fetchGroup(option: FetchGroup): Promise<ResponseFetchGroup> {
+  public async fetchGroup(option: FetchGroup): Promise<FetchResponseData> {
     try {
       const { groupId, owner } = option;
       this._validateInput(groupId);
@@ -612,7 +612,7 @@ export class RBAC extends Base {
 
   public async fetchGroupPermissions(
     option: FetchGroup
-  ): Promise<ResponseFetchGroup[]> {
+  ): Promise<FetchResponseData[]> {
     try {
       const { groupId, owner } = option;
       this._validateInput(groupId);
@@ -631,7 +631,7 @@ export class RBAC extends Base {
           type: CreateStorageKeysEnum.STANDARD,
         },
       ]);
-      let permissions: ResponseFetchGroup[] = [];
+      let permissions: FetchResponseData[] = [];
       const role2GroupData = (await api.query?.['peaqRbac']?.[
         'role2GroupStore'
       ](role2GroupStoreKey)) as unknown as Role2Group[];
@@ -708,7 +708,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the groups is fetched.
    */
 
-  public async fetchGroups(options: FetchGroups): Promise<ResponseFetchGroup[]> {
+  public async fetchGroups(options: FetchGroups): Promise<FetchResponseData[]> {
     try {
       const { owner } = options;
       if (!owner) throw new Error('Invalid owner address');
@@ -719,7 +719,7 @@ export class RBAC extends Base {
       if (!groups) {
         throw new Error(`No group is found of owner: ${owner}`);
       }
-      const responseData: ResponseFetchGroup[] = groups?.map((item) =>
+      const responseData: FetchResponseData[] = groups?.map((item) =>
         JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -736,7 +736,7 @@ export class RBAC extends Base {
 
   public async fetchPermission(
     option: FetchPermission
-  ): Promise<ResponseFetchGroup> {
+  ): Promise<FetchResponseData> {
     try {
       const { owner, permissionId } = option;
       this._validateInput(permissionId);
@@ -777,7 +777,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the permissions is fetched.
    */
 
-  public async fetchPermissions(options: FetchPermissions): Promise<ResponseFetchGroup[]> {
+  public async fetchPermissions(options: FetchPermissions): Promise<FetchResponseData[]> {
     try {
       const { owner } = options;
       if (!owner) throw new Error('Invalid owner address');
@@ -788,7 +788,7 @@ export class RBAC extends Base {
       if (!permissions) {
         throw new Error(`No permission is found of owner: ${owner}`);
       }
-      const responseData: ResponseFetchGroup[] = permissions?.map((item) =>
+      const responseData: FetchResponseData[] = permissions?.map((item) =>
         JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -803,7 +803,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRole(option: FetchRole): Promise<ResponseFetchGroup | undefined> {
+  public async fetchRole(option: FetchRole): Promise<FetchResponseData | undefined> {
     try {
       const { owner, roleId } = option;
       this._validateInput(roleId);
@@ -934,7 +934,7 @@ export class RBAC extends Base {
 
   public async fetchUserPermissions(
     option: FetchUserPermissions
-  ): Promise<ResponseFetchGroup[]> {
+  ): Promise<FetchResponseData[]> {
     try {
       const { owner, userId } = option;
       this._validateInput(userId);
@@ -969,7 +969,7 @@ export class RBAC extends Base {
         },
       ]);
 
-      const permissions: ResponseFetchGroup[] = [];
+      const permissions: FetchResponseData[] = [];
       const processed_roles = [];
 
       // Role2User

--- a/packages/sdk/src/modules/rbac/index.ts
+++ b/packages/sdk/src/modules/rbac/index.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4, v4 } from 'uuid';
-import { CreateStorageKeysEnum, FetchRoles } from '../../types';
+import { CreateStorageKeysEnum, } from '../../types';
 import { Base } from '../base';
 import { ApiPromise } from '@polkadot/api';
 import { createStorageKeys } from '../../utils';
@@ -102,6 +102,18 @@ interface FetchPermission {
 interface FetchRole {
   owner: Address;
   roleId: string;
+}
+
+interface FetchGroups {
+  owner: Address;
+}
+
+interface FetchPermissions {
+  owner: Address;
+}
+
+interface FetchRoles {
+  owner: Address;
 }
 
 interface FetchRolePermissions {
@@ -517,35 +529,28 @@ export class RBAC extends Base {
 
   /**
    * Fetch all roles.
-   * @param ownerAddress - The ownerAddress is public address of user or owner who created a roles.
+   * @param options - The ownerAddress is public address of user or owner who created a roles.
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRoles(ownerAddress: Address): Promise<FetchRoles[]> {
+  public async fetchRoles(options: FetchRoles): Promise<ResponseFetchGroup[]> {
     try {
-      if (!ownerAddress) throw new Error('Invalid owner address');
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
       const api = this._getApi();
+
       const roles = (await api.query?.['peaqRbac']?.['roleStore'](
-        ownerAddress
+        owner
       )) as unknown as Entity[];
+
       if (!roles) {
         throw new Error(
-          `Roles not exits with this owner address = ${ownerAddress}`
+          `Roles not exits with this owner address = ${owner}`
         );
       }
-      const responseData: FetchRoles[] = [];
-      roles.forEach((item, index) => {
-        const readAbleData = item.toHuman();
-        const stringFyData = JSON.stringify(readAbleData);
-        const parseData = JSON.parse(stringFyData);
-        const { id, name, enabled } = parseData;
-        let payload = {
-          id,
-          name,
-          enabled,
-        };
-        responseData.push(payload);
-      });
+      const responseData: ResponseFetchGroup[] = roles?.map(
+        (item) => JSON.parse(JSON.stringify(item.toHuman()))
+      );
       return responseData;
     } catch (error) {
       throw new Error(`Error occurred while fetching roles: ${error}`);
@@ -699,12 +704,14 @@ export class RBAC extends Base {
 
   /**
    * Fetch all groups.
-   * @param option - The option for fetch groups.
+   * @param options - The option for fetch groups.
    * @returns A promise that resolves when the groups is fetched.
    */
 
-  public async fetchGroups(owner: Address): Promise<FetchRoles[]> {
+  public async fetchGroups(options: FetchGroups): Promise<ResponseFetchGroup[]> {
     try {
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
       const api = this._getApi();
       const groups = (await api.query?.['peaqRbac']?.['groupStore'](
         owner
@@ -712,7 +719,7 @@ export class RBAC extends Base {
       if (!groups) {
         throw new Error(`No group is found of owner: ${owner}`);
       }
-      const responseData: FetchRoles[] = groups?.map((item) =>
+      const responseData: ResponseFetchGroup[] = groups?.map((item) =>
         JSON.parse(JSON.stringify(item.toHuman()))
       );
       return responseData;
@@ -766,22 +773,24 @@ export class RBAC extends Base {
 
   /**
    * Fetch all permissions.
-   * @param option - The option for fetch permissions.
+   * @param options - The option for fetch permissions.
    * @returns A promise that resolves when the permissions is fetched.
    */
 
-  public async fetchPermissions(owner: Address): Promise<ResponseFetchGroup[]> {
+  public async fetchPermissions(options: FetchPermissions): Promise<ResponseFetchGroup[]> {
     try {
-      const api = await this._getApi();
+      const { owner } = options;
+      if (!owner) throw new Error('Invalid owner address');
+      const api = this._getApi();
       const permissions = (await api.query?.['peaqRbac']?.['permissionStore'](
         owner
       )) as unknown as Entity[];
-      const responseData: FetchRoles[] = permissions?.map((item) =>
-        JSON.parse(JSON.stringify(item.toHuman()))
-      );
       if (!permissions) {
         throw new Error(`No permission is found of owner: ${owner}`);
       }
+      const responseData: ResponseFetchGroup[] = permissions?.map((item) =>
+        JSON.parse(JSON.stringify(item.toHuman()))
+      );
       return responseData;
     } catch (error) {
       throw new Error(`Error occurred while fetching permissions: ${error}`);
@@ -794,7 +803,7 @@ export class RBAC extends Base {
    * @returns A promise that resolves when the role is fetched.
    */
 
-  public async fetchRole(option: FetchRole): Promise<FetchRoles | undefined> {
+  public async fetchRole(option: FetchRole): Promise<ResponseFetchGroup | undefined> {
     try {
       const { owner, roleId } = option;
       this._validateInput(roleId);

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -73,7 +73,7 @@ export interface SignTransction{
   statusCallback?: (result: ISubmittableResult) => void;
 }
 
-export interface ResponseFetchGroup{
+export interface FetchResponseData{
   id: string;
   name: string;
   enabled: boolean;

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -73,12 +73,6 @@ export interface SignTransction{
   statusCallback?: (result: ISubmittableResult) => void;
 }
 
-export interface FetchRoles{
-  id: string;
-  name: string;
-  enabled: boolean;
-}
-
 export interface ResponseFetchGroup{
   id: string;
   name: string;


### PR DESCRIPTION
Goal: To create an object interface with address type to fix fetch errors in roles, groups, and permissions.

- Previously the only working syntax for fetch all: await rbac.fetchGroups(owner.address);

That is inconsistent with all other functions that always pass an object, for example: await rbac.createRole({name: role_name'})

- Fetches now works with: await rbac.fetchGroups({owner: owner.address}); Please note the added {} which is the syntax all of our other functions use.