### PR TITLE
Fix/1208238364944982 Generate Did Hash Offline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peaq-network",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peaq-network",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@polkadot/api": "12.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peaq-network",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "scripts": {
     "prepare": "ts-patch install -s"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "peaq network sdk",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/src/modules/did/did.spec.ts
+++ b/packages/sdk/src/modules/did/did.spec.ts
@@ -37,7 +37,6 @@ describe('Did', () => {
   let user2: KeyringPair;
   let sdk: SDK;
   let sdk2: SDK;
-  let sdkOffline: SDK;
 
   beforeAll(async () => {
     keyring = new Keyring({ type: 'sr25519' });
@@ -48,7 +47,6 @@ describe('Did', () => {
     user2 = keyring2.addFromUri(SEED2);
     sdk = await SDK.createInstance({baseUrl: BASE_URL, seed: SEED});
     sdk2 = await SDK.createInstance({baseUrl: BASE_URL, seed: SEED2});
-    sdkOffline = await SDK.createOfflineInstance();
   }, 40000);
 
   afterAll(async () => {
@@ -67,19 +65,19 @@ describe('Did', () => {
         const address6 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12PI';  // address that is proper length but has I included
         const address7 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pl';  // address that is proper length but has I included
   
-        await expect(sdkOffline.did.generate({address: address1}))
+        await expect(SDK.generateDidDocument({address: address1}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address2}))
+        await expect(SDK.generateDidDocument({address: address2}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address3}))
+        await expect(SDK.generateDidDocument({address: address3}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address4}))
+        await expect(SDK.generateDidDocument({address: address4}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address5}))
+        await expect(SDK.generateDidDocument({address: address5}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address6}))
+        await expect(SDK.generateDidDocument({address: address6}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address7}))
+        await expect(SDK.generateDidDocument({address: address7}))
           .rejects.toThrow(new CreateDidError(address_error));
       });
 
@@ -89,18 +87,18 @@ describe('Did', () => {
         const address3 = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641';         // address has an one less char at the end (41 chars)
         const address4 = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641Z';        // address is proper length but has invalid hex value of 'Z'
 
-        await expect(sdkOffline.did.generate({address: address1}))
+        await expect(SDK.generateDidDocument({address: address1}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address2}))
+        await expect(SDK.generateDidDocument({address: address2}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address3}))
+        await expect(SDK.generateDidDocument({address: address3}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdkOffline.did.generate({address: address4}))
+        await expect(SDK.generateDidDocument({address: address4}))
           .rejects.toThrow(new CreateDidError(address_error));
       });
   
       it('generate did', async () => {
-        const result = await sdkOffline.did.generate({address: user.address});
+        const result = await SDK.generateDidDocument({address: user.address});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -108,7 +106,7 @@ describe('Did', () => {
       });
 
       it('generate did Substrate address', async () => {
-        const result = await sdkOffline.did.generate({address: user.address});
+        const result = await SDK.generateDidDocument({address: user.address});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -123,7 +121,7 @@ describe('Did', () => {
 
       it('generate did Ethereum address', async () => {
         const addressETH = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641C';
-        const result = await sdkOffline.did.generate({address: addressETH, customDocumentFields: {controller: addressETH}});
+        const result = await SDK.generateDidDocument({address: addressETH, customDocumentFields: {controller: addressETH}});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -155,7 +153,7 @@ describe('Did', () => {
           }]
       }
 
-        const result = await sdkOffline.did.generate({address: user.address, customDocumentFields: customFields});
+        const result = await SDK.generateDidDocument({address: user.address, customDocumentFields: customFields});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -188,7 +186,7 @@ describe('Did', () => {
           }]
       }
 
-        const result = await sdkOffline.did.generate({address: addressETH, customDocumentFields: customFields});
+        const result = await SDK.generateDidDocument({address: addressETH, customDocumentFields: customFields});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);

--- a/packages/sdk/src/modules/did/did.spec.ts
+++ b/packages/sdk/src/modules/did/did.spec.ts
@@ -1,12 +1,11 @@
 import dotenv from 'dotenv';
 import * as peaqDidProto from 'peaq-did-proto-js';
-import { ApiPromise, WsProvider } from '@polkadot/api';
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { hexToU8a } from '@polkadot/util';
+import { hexToU8a,  } from '@polkadot/util';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
 import type { DidDocument, ReadDidResponse } from '../../types';
-import { CustomDocumentFields, Did } from './index';
-import { unsubscribeRuntimeVersion } from '../../utils';
+import { CustomDocumentFields } from './index';
 import { CreateDidError, ReadDidError, UpdateDidError, RemoveDidError} from '../../utils/errors';
 import { Main as SDK } from '../main';
 
@@ -32,30 +31,27 @@ const address_error = `AddressError: Incorrect Substrate SS58/Ethereum Address f
  * This flow ensures that a user needs less than .2 token to execute all tests and funds will be returned back.
  */
 describe('Did', () => {
-  let api: ApiPromise;
   let keyring: Keyring;
   let keyring2: Keyring;
   let user: KeyringPair;
   let user2: KeyringPair;
-  let did: Did;
-  let did2: Did;
   let sdk: SDK;
+  let sdk2: SDK;
+  let sdkOffline: SDK;
 
   beforeAll(async () => {
-    const provider = new WsProvider(BASE_URL);
-    api = await ApiPromise.create({ provider, noInitWarn: true });
     keyring = new Keyring({ type: 'sr25519' });
     keyring2 = new Keyring({ type: 'sr25519' });
+    await cryptoWaitReady();
     user = keyring.addFromUri(SEED);
+    await cryptoWaitReady();
     user2 = keyring2.addFromUri(SEED2);
-    did = new Did(api, { pair: user });
-    did2 = new Did(api, { pair: user2 });
-    sdk = await SDK.createOfflineInstance();
+    sdk = await SDK.createInstance({baseUrl: BASE_URL, seed: SEED});
+    sdk2 = await SDK.createInstance({baseUrl: BASE_URL, seed: SEED2});
+    sdkOffline = await SDK.createOfflineInstance();
   }, 40000);
 
   afterAll(async () => {
-    await unsubscribeRuntimeVersion(api);
-    await api?.disconnect();
   });
 
   /**
@@ -71,19 +67,19 @@ describe('Did', () => {
         const address6 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12PI';  // address that is proper length but has I included
         const address7 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pl';  // address that is proper length but has I included
   
-        await expect(sdk.did.generate({address: address1}))
+        await expect(sdkOffline.did.generate({address: address1}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address2}))
+        await expect(sdkOffline.did.generate({address: address2}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address3}))
+        await expect(sdkOffline.did.generate({address: address3}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address4}))
+        await expect(sdkOffline.did.generate({address: address4}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address5}))
+        await expect(sdkOffline.did.generate({address: address5}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address6}))
+        await expect(sdkOffline.did.generate({address: address6}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address7}))
+        await expect(sdkOffline.did.generate({address: address7}))
           .rejects.toThrow(new CreateDidError(address_error));
       });
 
@@ -93,18 +89,18 @@ describe('Did', () => {
         const address3 = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641';         // address has an one less char at the end (41 chars)
         const address4 = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641Z';        // address is proper length but has invalid hex value of 'Z'
 
-        await expect(sdk.did.generate({address: address1}))
+        await expect(sdkOffline.did.generate({address: address1}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address2}))
+        await expect(sdkOffline.did.generate({address: address2}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address3}))
+        await expect(sdkOffline.did.generate({address: address3}))
           .rejects.toThrow(new CreateDidError(address_error));
-        await expect(sdk.did.generate({address: address4}))
+        await expect(sdkOffline.did.generate({address: address4}))
           .rejects.toThrow(new CreateDidError(address_error));
       });
   
       it('generate did', async () => {
-        const result = await sdk.did.generate({address: user.address});
+        const result = await sdkOffline.did.generate({address: user.address});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -112,7 +108,7 @@ describe('Did', () => {
       });
 
       it('generate did Substrate address', async () => {
-        const result = await sdk.did.generate({address: user.address});
+        const result = await sdkOffline.did.generate({address: user.address});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -127,7 +123,7 @@ describe('Did', () => {
 
       it('generate did Ethereum address', async () => {
         const addressETH = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641C';
-        const result = await sdk.did.generate({address: addressETH, customDocumentFields: {controller: addressETH}});
+        const result = await sdkOffline.did.generate({address: addressETH, customDocumentFields: {controller: addressETH}});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -159,7 +155,7 @@ describe('Did', () => {
           }]
       }
 
-        const result = await sdk.did.generate({address: user.address, customDocumentFields: customFields});
+        const result = await sdkOffline.did.generate({address: user.address, customDocumentFields: customFields});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -192,7 +188,7 @@ describe('Did', () => {
           }]
       }
 
-        const result = await sdk.did.generate({address: addressETH, customDocumentFields: customFields});
+        const result = await sdkOffline.did.generate({address: addressETH, customDocumentFields: customFields});
         const did_hash = result.value;
         // check did hash return value: starts with '0x' and only contains hexadecimal values
         expect(did_hash.startsWith('0x')).toBe(true);
@@ -213,7 +209,7 @@ describe('Did', () => {
   describe('create()', () => {
     // tests error when an empty name is set
     it('create did with no name set', async () => {
-      await expect(did.create({name: ''}))
+      await expect(sdk.did.create({name: ''}))
         .rejects.toThrow(new CreateDidError('NameError: Name is required when creating a DID.'));
     });
     // tests errors when an incorrect SS58 address is passed. 
@@ -229,51 +225,51 @@ describe('Did', () => {
       const address6 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12PI';  // address that is proper length but has I included
       const address7 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pl';  // address that is proper length but has I included
 
-      await expect(did.create({name: new_did, address: address1}))
+      await expect(sdk.did.create({name: new_did, address: address1}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address2}))
+      await expect(sdk.did.create({name: new_did, address: address2}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address3}))
+      await expect(sdk.did.create({name: new_did, address: address3}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address4}))
+      await expect(sdk.did.create({name: new_did, address: address4}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address5}))
+      await expect(sdk.did.create({name: new_did, address: address5}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address6}))
+      await expect(sdk.did.create({name: new_did, address: address6}))
         .rejects.toThrow(new CreateDidError(address_error));
-      await expect(did.create({name: new_did, address: address7}))
+      await expect(sdk.did.create({name: new_did, address: address7}))
         .rejects.toThrow(new CreateDidError(address_error));
     });
 
     // throws an error when a seed phrase is not 12 or 24 words long
     it('create did with an incorrect seed', async () => {
       const new_did  = 'did-test-1';
-      await expect(did.create({name: new_did, seed: 'My incorrect seed phrase'}))
+      await expect(sdk.did.create({name: new_did, seed: 'My incorrect seed phrase'}))
         .rejects.toThrow(new CreateDidError('SeedError: Invalid seed phrase length: Seed phrase must be either 12 or 24 words long.'));
     });
 
     // creates, reads, and removes to align with expected
     it('create single did with no custom fields', async () => {
       const new_did  = 'did-test-1';
-      await createReadRemove(new_did, did, user, null, null, null);
+      await createReadRemove(new_did, sdk, user, null, null, null);
     }, 150000);
 
     // creates, reads, and removes to align with expected
     it('create single did with proper address initialization', async () => {
       const new_did  = 'did-test-1';
       const address = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pg';
-      await createReadRemove(new_did, did, user, null, null, address);
+      await createReadRemove(new_did, sdk, user, null, null, address);
     }, 150000);
 
     it('create single did with custom seed', async () => {
       const new_did  = 'did-test-1';
       const seed = SEED;
-      await createReadRemove(new_did, did, user, null, seed, null);
+      await createReadRemove(new_did, sdk, user, null, seed, null);
     }, 150000);
 
     it('create did by setting address manually based on keyring', async () => {
       const new_did  = 'did-test-1';
-      await createReadRemove(new_did, did, user, null, null, user.address);
+      await createReadRemove(new_did, sdk, user, null, null, user.address);
     }, 150000);
 
     it('add a custom prefix when creating a did', async () => {
@@ -282,19 +278,19 @@ describe('Did', () => {
       const customFields: CustomDocumentFields = {
         prefix: prefix
       }
-      await createReadRemove(new_did, did, user, customFields, null, user.address);
+      await createReadRemove(new_did, sdk, user, customFields, null, user.address);
     }, 150000);
 
     // try to create a did of the same name -> expect error
     it('create did of same name error', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
-      await expect(did.create({ name: new_did }))
+      await expect(sdk.did.create({ name: new_did }))
         .rejects.toThrow("Error: AttributeAlreadyExist for peaqDid.");
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
@@ -316,7 +312,7 @@ describe('Did', () => {
         }]
       }
       // test
-      await createReadRemove(new_did, did, user, customFields, null, null);
+      await createReadRemove(new_did, sdk, user, customFields, null, null);
     }, 150000);
 
     it('create custom did without the necessary service fields', async () => {
@@ -330,7 +326,7 @@ describe('Did', () => {
           },]
       }
 
-      await expect(did.create({name: new_did,customDocumentFields: customFields}))
+      await expect(sdk.did.create({name: new_did,customDocumentFields: customFields}))
         .rejects.toThrow('Error: Either service endpoint or data is required for service');
     });
 
@@ -348,7 +344,7 @@ describe('Did', () => {
           hash: '0x123'
         }
       }
-      await createReadRemove(new_did, did, user, customFields, null, null);
+      await createReadRemove(new_did, sdk, user, customFields, null, null);
     }, 150000);
 
     // verification, signature, and service custom fields
@@ -370,7 +366,7 @@ describe('Did', () => {
           serviceEndpoint: 'http://localhost:8080/ipfs/'
         }]
       }
-      await createReadRemove(new_did, did, user, customFields, null, null);
+      await createReadRemove(new_did, sdk, user, customFields, null, null);
     }, 150000);
 
     it('create custom did with verification (sr), signature, & service custom fields', async () => {
@@ -391,7 +387,7 @@ describe('Did', () => {
           serviceEndpoint: 'http://localhost:8080/ipfs/'
         }]
       }
-      await createReadRemove(new_did, did, user, customFields, null, null);
+      await createReadRemove(new_did, sdk, user, customFields, null, null);
     }, 150000);
 
     it('create custom did with verification publicKeyMultibase set by user manually', async () => {
@@ -413,7 +409,7 @@ describe('Did', () => {
           serviceEndpoint: 'http://localhost:8080/ipfs/'
         }]
       }
-      await createReadRemove(new_did, did, user, customFields, null, null);
+      await createReadRemove(new_did, sdk, user, customFields, null, null);
     }, 150000);
   });
 
@@ -425,13 +421,13 @@ describe('Did', () => {
   describe('read()', () => {
     it('should throw an error when name is not provided', async () => {
       await expect(
-        did.read({ address: user.address, name: '' })
+        sdk.did.read({ address: user.address, name: '' })
       ).rejects.toThrow('Name is required');
     });
 
     it('should return null when DID is not found', async () => {
       const name = '1';
-      await expect(did.read({ address: user.address, name })).resolves.toBeNull();
+      await expect(sdk.did.read({ address: user.address, name })).resolves.toBeNull();
     });
     it('read did with an incorrect address', async () => {
       const new_did  = 'did-test-1';
@@ -443,26 +439,26 @@ describe('Did', () => {
       const address6 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12PI';  // address that is proper length but has I included
       const address7 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pl';  // address that is proper length but has I included
 
-      await expect(did.read({name: new_did, address: address1}))
+      await expect(sdk.did.read({name: new_did, address: address1}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address2}))
+      await expect(sdk.did.read({name: new_did, address: address2}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address3}))
+      await expect(sdk.did.read({name: new_did, address: address3}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address4}))
+      await expect(sdk.did.read({name: new_did, address: address4}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address5}))
+      await expect(sdk.did.read({name: new_did, address: address5}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address6}))
+      await expect(sdk.did.read({name: new_did, address: address6}))
         .rejects.toThrow(new ReadDidError(address_error));
-      await expect(did.read({name: new_did, address: address7}))
+      await expect(sdk.did.read({name: new_did, address: address7}))
         .rejects.toThrow(new ReadDidError(address_error));
     });
 
     it('read a known did with address and proper name passed', async () => {
       const known_did  = 'did-test';
 
-      const read_did = await did.read({name: known_did, address: user.address}) ;
+      const read_did = await sdk.did.read({name: known_did, address: user.address}) ;
       expect(read_did).toBeDefined();
       await readDid(read_did as ReadDidResponse, known_did, user, null);
     })
@@ -480,7 +476,7 @@ describe('Did', () => {
         type: 'machine',
         data: 'test_data'
       }]}
-      await expect(did.update({name: '', customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: '', customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError('NameError: Name is required when updating a DID.'));
     });
     // throws an error when a seed phrase is not 12 or 24 words long
@@ -491,7 +487,7 @@ describe('Did', () => {
         type: 'machine',
         data: 'test_data'
       }]}
-      await expect(did.update({name: known_did, seed: 'My incorrect seed phrase', customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: known_did, seed: 'My incorrect seed phrase', customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError('SeedError: Invalid seed phrase length: Seed phrase must be either 12 or 24 words long.'));
     });
     it('update did with an incorrect address', async () => {
@@ -510,19 +506,19 @@ describe('Did', () => {
         data: 'test_data'
       }]}
 
-      await expect(did.update({name: new_did, address: address1, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address1, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address2, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address2, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address3, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address3, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address4, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address4, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address5, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address5, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address6, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address6, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
-      await expect(did.update({name: new_did, address: address7, customDocumentFields: customFields}))
+      await expect(sdk.did.update({name: new_did, address: address7, customDocumentFields: customFields}))
         .rejects.toThrow(new UpdateDidError(address_error));
     });
     it('try to update attribute that does not exist', async() => {
@@ -532,7 +528,7 @@ describe('Did', () => {
           type: "Ed25519VerificationKey2020"
         }],
       }
-      await expect(did.update({
+      await expect(sdk.did.update({
         name: new_did,
         customDocumentFields: customFields
       })).rejects.toThrow(new UpdateDidError(`DidNotFoundError: DID Document of name ${new_did} for the account address ${user.address} was not found.`));
@@ -542,7 +538,7 @@ describe('Did', () => {
     it('try to update a did from an address the owner does not own', async() => {
       const new_did = 'did-test-1';
       // create a new did for user's did
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
   
       const customFields: CustomDocumentFields = {
         verifications: [{
@@ -551,14 +547,14 @@ describe('Did', () => {
       }
 
       // use the did2 instance of sdk which is created using the user2 keyring to try to update a did they do not own. Expects to throw an error.
-      await expect(did2.update({
+      await expect(sdk2.did.update({
         name: new_did,
         address: user.address,
         customDocumentFields: customFields
       })).rejects.toThrow(new UpdateDidError("Error: AttributeAuthorizationFailed for peaqDid."));
   
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
 
@@ -566,7 +562,7 @@ describe('Did', () => {
     
     it('should update a DID', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
       const customFields: CustomDocumentFields = {
         prefix: 'custom_name',
@@ -586,26 +582,26 @@ describe('Did', () => {
         }]
       }
       
-      const result = await did.update({
+      const result = await sdk.did.update({
         name: new_did,
         customDocumentFields: customFields
       });
 
       expect(result).toBeDefined();
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       await readDid(result2 as ReadDidResponse, new_did, user, customFields);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
 
     it('should update a DID with a custom prefix', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
       const customFields: CustomDocumentFields = {
         prefix: 'custom_name',
@@ -624,18 +620,18 @@ describe('Did', () => {
         }]
       }
       
-      const result = await did.update({
+      const result = await sdk.did.update({
         name: new_did,
         customDocumentFields: customFields
       });
       expect(result).toBeDefined();
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       await readDid(result2 as ReadDidResponse, new_did, user, customFields);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
@@ -648,7 +644,7 @@ describe('Did', () => {
       }
 
       // create new did to see if the prefix stays
-      await did.create({name: new_did, customDocumentFields: customFields});
+      await sdk.did.create({name: new_did, customDocumentFields: customFields});
 
       // add verification, but do not change the prefix
       const customFields2: CustomDocumentFields = {
@@ -657,10 +653,10 @@ describe('Did', () => {
         }]
       }
       // add verification method. Should use the previously set prefix in the create function.
-      const result = await did.update({name: new_did, customDocumentFields: customFields2});
+      const result = await sdk.did.update({name: new_did, customDocumentFields: customFields2});
 
       expect(result).toBeDefined();
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       // custom fields to check which includes prefix and verification
@@ -674,7 +670,7 @@ describe('Did', () => {
       await readDid(result2 as ReadDidResponse, new_did, user, customFields3);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 100000);
@@ -687,7 +683,7 @@ describe('Did', () => {
       }
 
       // create new did to see if the prefix stays
-      await did.create({name: new_did, customDocumentFields: customFields});
+      await sdk.did.create({name: new_did, customDocumentFields: customFields});
 
       const customFields2: CustomDocumentFields = {
         prefix: 'new_prefix',
@@ -696,24 +692,24 @@ describe('Did', () => {
         }]
       }
       // add verification method. Uses the new set prefix.
-      const result = await did.update({name: new_did, customDocumentFields: customFields2});
+      const result = await sdk.did.update({name: new_did, customDocumentFields: customFields2});
 
       expect(result).toBeDefined();
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       // use the previously set customFields2 that will overwrite the previous prefix
       await readDid(result2 as ReadDidResponse, new_did, user, customFields2);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
 
     it('should update a DID with an address passed', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
       const customFields: CustomDocumentFields = {
         verifications: [{
@@ -731,27 +727,27 @@ describe('Did', () => {
         }]
       }
       
-      const result = await did.update({
+      const result = await sdk.did.update({
         name: new_did,
         address: user.address,
         customDocumentFields: customFields
       });
       expect(result).toBeDefined();
 
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       await readDid(result2 as ReadDidResponse, new_did, user, customFields);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
 
     it('should update a DID with a seed passed', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
       const customFields: CustomDocumentFields = {
         verifications: [{
@@ -769,27 +765,27 @@ describe('Did', () => {
         }]
       }
       
-      const result = await did.update({
+      const result = await sdk.did.update({
         name: new_did,
         seed: SEED,
         customDocumentFields: customFields
       });
       expect(result).toBeDefined();
 
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       await readDid(result2 as ReadDidResponse, new_did, user, customFields);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
 
     it('should update a DID with a custom publicKeyMultibase set', async () => {
       const new_did  = 'did-test-1';
-      await did.create({name: new_did});
+      await sdk.did.create({name: new_did});
 
       const customFields: CustomDocumentFields = {
         verifications: [{
@@ -808,19 +804,19 @@ describe('Did', () => {
         }]
       }
       
-      const result = await did.update({
+      const result = await sdk.did.update({
         name: new_did,
         customDocumentFields: customFields
       });
       expect(result).toBeDefined();
 
-      const result2 = await did.read({ address: user.address, name: new_did });
+      const result2 = await sdk.did.read({ address: user.address, name: new_did });
       expect(result2).toBeDefined();
 
       await readDid(result2 as ReadDidResponse, new_did, user, customFields);
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
@@ -836,7 +832,7 @@ describe('Did', () => {
     it('try remove DID not present', async () => {
       const new_did = 'did-test-1';
 
-      await expect(did.remove({name: new_did}))
+      await expect(sdk.did.remove({name: new_did}))
         .rejects.toThrow(new RemoveDidError(`DidNotFoundError: DID Document of name ${new_did} for the account address ${user.address} was not found.`));
 
     });
@@ -844,7 +840,7 @@ describe('Did', () => {
     // throws an error when a seed phrase is not 12 or 24 words long
     it('create did with an incorrect seed', async () => {
       const new_did  = 'did-test-1';
-      await expect(did.remove({name: new_did, seed: 'My incorrect seed phrase'}))
+      await expect(sdk.did.remove({name: new_did, seed: 'My incorrect seed phrase'}))
         .rejects.toThrow(new RemoveDidError('SeedError: Invalid seed phrase length: Seed phrase must be either 12 or 24 words long.'));
     });
 
@@ -858,26 +854,26 @@ describe('Did', () => {
       const address6 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12PI';  // address that is proper length but has I included
       const address7 = '5Df42mkztLtkksgQuLy4YV6hmhzdjYvDknoxHv1QBkaY12Pl';  // address that is proper length but has I included
 
-      await expect(did.remove({name: new_did, address: address1}))
+      await expect(sdk.did.remove({name: new_did, address: address1}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address2}))
+      await expect(sdk.did.remove({name: new_did, address: address2}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address3}))
+      await expect(sdk.did.remove({name: new_did, address: address3}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address4}))
+      await expect(sdk.did.remove({name: new_did, address: address4}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address5}))
+      await expect(sdk.did.remove({name: new_did, address: address5}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address6}))
+      await expect(sdk.did.remove({name: new_did, address: address6}))
         .rejects.toThrow(new RemoveDidError(address_error));
-      await expect(did.remove({name: new_did, address: address7}))
+      await expect(sdk.did.remove({name: new_did, address: address7}))
         .rejects.toThrow(new RemoveDidError(address_error));
     });
 
     it('create & remove a DID', async () => {
       const new_did = 'did-test-1';
-      await did.create({name: new_did});
-      const result = await did.remove({name: new_did});
+      await sdk.did.create({name: new_did});
+      const result = await sdk.did.remove({name: new_did});
 
       expect(result?.block_hash).toBeDefined();
       expect(typeof result?.unsubscribe).toBe('function');
@@ -885,28 +881,28 @@ describe('Did', () => {
 
     it('try to remove DID they does not exist', async () =>{
       const new_did = 'did-test-1';
-      await did.create({name: new_did}); // create did using user key
+      await sdk.did.create({name: new_did}); // create did using user key
 
-      await expect(did2.remove({name: new_did}))
+      await expect(sdk2.did.remove({name: new_did}))
         .rejects.toThrow(new RemoveDidError(`DidNotFoundError: DID Document of name ${new_did} for the account address ${user2.address} was not found.`));
 
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
 
     it('try to remove DID they do not own', async () =>{
       const new_did = 'did-test-1';
-      await did.create({name: new_did}); // create did using user key
+      await sdk.did.create({name: new_did}); // create did using user key
 
-      await expect(did2.remove({name: new_did, address: user.address}))
+      await expect(sdk2.did.remove({name: new_did, address: user.address}))
         .rejects.toThrow(new RemoveDidError("Error: AttributeAuthorizationFailed for peaqDid."));
 
 
       // remove did for cleanup
-      const removeResult = await did.remove({name: new_did});
+      const removeResult = await sdk.did.remove({name: new_did});
       expect(removeResult?.block_hash).toBeDefined();
       expect(typeof removeResult?.unsubscribe).toBe('function');
     }, 150000);
@@ -929,8 +925,8 @@ describe('Did', () => {
  * @returns - None
  */
 
-async function createReadRemove(new_did: string, did: Did, user: KeyringPair, customFields: CustomDocumentFields | null, seed: string | null, address: string | null) {
-  const result = await did.create({
+async function createReadRemove(new_did: string, sdk: SDK, user: KeyringPair, customFields: CustomDocumentFields | null, seed: string | null, address: string | null) {
+  const result = await sdk.did.create({
     name: new_did,
     ...(address !== null && {address: address}),
     ...(customFields && { customDocumentFields: customFields }),
@@ -941,7 +937,7 @@ async function createReadRemove(new_did: string, did: Did, user: KeyringPair, cu
   // expect(typeof result.unsubscribe).toBe('function');
 
   // read newly created did
-  const read_did = await did.read({
+  const read_did = await sdk.did.read({
     name: new_did
   });
 
@@ -956,7 +952,7 @@ async function createReadRemove(new_did: string, did: Did, user: KeyringPair, cu
   await readDid(read_did as ReadDidResponse, new_did, user, customFields || null);
 
   // remove did for cleanup
-  const removeResult = await did.remove({name: new_did});
+  const removeResult = await sdk.did.remove({name: new_did});
   expect(removeResult?.block_hash).toBeDefined();
   expect(typeof removeResult?.unsubscribe).toBe('function');
 }

--- a/packages/sdk/src/modules/did/index.ts
+++ b/packages/sdk/src/modules/did/index.ts
@@ -48,7 +48,7 @@ type Service = {
   data?: string;
 }
 
-interface GenerateDidOptions {
+export interface GenerateDidOptions {
   address: Address;
   customDocumentFields?: CustomDocumentFields;
 }
@@ -85,7 +85,7 @@ interface RemoveDidOptions {
   seed?: string;
 }
 
-interface GenerateDidResult {
+export interface GenerateDidResult {
   value: string;
 }
 

--- a/packages/sdk/src/modules/did/index.ts
+++ b/packages/sdk/src/modules/did/index.ts
@@ -155,7 +155,7 @@ export class Did extends Base {
    * Creates a new DID by adding a new attribute to the PEAQ DID registry.
    * 
    * @param options - The options for creating the DID.
-   * @returns block_hash - Hash that is searchable on a block explorer to see transaction.
+   * @returns CreateDidResult - Contains the block_hash of the executed transaction and unsubscribe() to terminate event listening.
    */
   public async create(
     options: CreateDidOptions,
@@ -245,6 +245,12 @@ export class Did extends Base {
     }
   }
 
+  /**
+   * Updates a previously created DID Document and overwrites the previously set data.
+   * 
+   * @param options: UpdateDidOptions = {address: Address, customDocumentFields?: CustomDocumentFields}
+   * @returns UpdateDidResult - Contains log information, block_hash of the executed transaction and unsubscribe() to terminate event listening.
+   */
   public async update(options: UpdateDidOptions,
     statusCallback?: (result: ISubmittableResult) => void | Promise<void>
   ): Promise<UpdateDidResult | null> {
@@ -298,7 +304,13 @@ export class Did extends Base {
     }
   }
 
-  // TODO add custom errors
+  
+  /**
+   * Removes a previously created DID Document.
+   * 
+   * @param options: UpdateDidOptions = {address: Address, customDocumentFields?: CustomDocumentFields}
+   * @returns RemoveDidResult - Contains log information, block_hash of the executed transaction and unsubscribe() to terminate event listening.
+   */
   public async remove(options: RemoveDidOptions,
     statusCallback?: (result: ISubmittableResult) => void | Promise<void>
   ): Promise<RemoveDidResult | null> {

--- a/packages/sdk/src/modules/main/index.ts
+++ b/packages/sdk/src/modules/main/index.ts
@@ -17,19 +17,18 @@ export class Main extends Base {
   private readonly _options: Options;
   protected override _api: ApiPromise;
   private _metadata: SDKMetadata;
-
+  
   public did: Did;
   public rbac: RBAC;
-  static offlineMode: boolean;
 
   constructor(options: Options) {
-      super();
-      this._options = options;
-      this._api = this._createApi(options);
-      this._metadata = {};
+    super();
+    this._options = options;
+    this._api = this._createApi(options);
+    this._metadata = {};
 
-      this.did = new Did(this._api, this._metadata);
-      this.rbac = new RBAC(this._api, this._metadata);
+    this.did = new Did(this._api, this._metadata);
+    this.rbac = new RBAC(this._api, this._metadata);
   }
 
   /**
@@ -39,7 +38,6 @@ export class Main extends Base {
    * @returns The created instance of the SDK.
    */
   public static async createInstance(options: Options): Promise<Main> {
-    this.offlineMode = false;
     await cryptoWaitReady();
     const sdk = new Main(options);
     await sdk.connect();

--- a/packages/sdk/src/modules/main/index.ts
+++ b/packages/sdk/src/modules/main/index.ts
@@ -14,19 +14,33 @@ import { RBAC } from "../rbac";
  */
 export class Main extends Base {
   private readonly _options: Options;
-  protected override _api: ApiPromise;
+  protected override _api: ApiPromise | undefined;
   private _metadata: SDKMetadata;
+
   public did: Did;
   public rbac: RBAC;
+  static offlineMode: boolean;
 
   constructor(options: Options) {
-    super();
-    this._options = options;
-    this._api = this._createApi(options);
-    this._metadata = {};
+    if (Main.offlineMode){
+      // if in offline mode initialize to empty data
+      super();
+      this._options = {};
+      this._api = undefined;
+      this._metadata = {};
 
-    this.did = new Did(this._api, this._metadata);
-    this.rbac = new RBAC(this._api, this._metadata);
+      this.did = new Did();
+      this.rbac = new RBAC();
+    }
+    else {
+      super();
+      this._options = options;
+      this._api = this._createApi(options);
+      this._metadata = {};
+
+      this.did = new Did(this._api, this._metadata);
+      this.rbac = new RBAC(this._api, this._metadata);
+    }
   }
 
   /**
@@ -36,6 +50,7 @@ export class Main extends Base {
    * @returns The created instance of the SDK.
    */
   public static async createInstance(options: Options): Promise<Main> {
+    this.offlineMode = false;
     await cryptoWaitReady();
     const sdk = new Main(options);
     await sdk.connect();
@@ -49,6 +64,7 @@ export class Main extends Base {
    * @returns The created offline instance of the SDK.
    */
     public static async createOfflineInstance(): Promise<Main> {
+      this.offlineMode = true;
       const sdk = new Main({});
       return sdk;
     }

--- a/packages/sdk/src/modules/main/index.ts
+++ b/packages/sdk/src/modules/main/index.ts
@@ -6,15 +6,16 @@ import { unsubscribeRuntimeVersion } from '../../utils';
 import type { Options, SDKMetadata } from '../../types';
 
 import { Base } from '../base';
-import { Did } from '../did';
+import { GenerateDidOptions, GenerateDidResult, Did } from '../did';
 import { RBAC } from "../rbac";
+
 
 /**
  * Main class for interacting with the SDK.
  */
 export class Main extends Base {
   private readonly _options: Options;
-  protected override _api: ApiPromise | undefined;
+  protected override _api: ApiPromise;
   private _metadata: SDKMetadata;
 
   public did: Did;
@@ -22,17 +23,6 @@ export class Main extends Base {
   static offlineMode: boolean;
 
   constructor(options: Options) {
-    if (Main.offlineMode){
-      // if in offline mode initialize to empty data
-      super();
-      this._options = {};
-      this._api = undefined;
-      this._metadata = {};
-
-      this.did = new Did();
-      this.rbac = new RBAC();
-    }
-    else {
       super();
       this._options = options;
       this._api = this._createApi(options);
@@ -40,7 +30,6 @@ export class Main extends Base {
 
       this.did = new Did(this._api, this._metadata);
       this.rbac = new RBAC(this._api, this._metadata);
-    }
   }
 
   /**
@@ -58,16 +47,15 @@ export class Main extends Base {
   }
 
   /**
-   * Creates a new offline instance of the SDK to use the generate function.
+   * Generates a hash of the DID Document without connecting to the chain.
    *
-   * @param None
-   * @returns The created offline instance of the SDK.
+   * @param GenerateDidOptions - The options for generating a DID.
+   * @returns The hash value of the generated DID document
    */
-    public static async createOfflineInstance(): Promise<Main> {
-      this.offlineMode = true;
-      const sdk = new Main({});
-      return sdk;
-    }
+  public static async generateDidDocument(options: GenerateDidOptions): Promise<GenerateDidResult> {
+    const did = new Did();
+    return did.generate(options);
+  }
 
   /**
    * Connects the SDK to the network.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/types",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "Apache-2.0",
   "description": "Typescript definitions for the peaq network",
   "repository": {


### PR DESCRIPTION
When a user wants to generate a DID Document hash this new updates allows them to do so offline. Using the SDK.generateDidDocument() function a did hash value is returned back which can be used to manually set the value.