### PR TITLE
fix: remove hash prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peaq-network",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peaq-network",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@polkadot/api": "12.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peaq-network",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "scripts": {
     "prepare": "ts-patch install -s"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "peaq network sdk",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/src/modules/did/did.spec.ts
+++ b/packages/sdk/src/modules/did/did.spec.ts
@@ -100,17 +100,15 @@ describe('Did', () => {
       it('generate did', async () => {
         const result = await SDK.generateDidDocument({address: user.address});
         const did_hash = result.value;
-        // check did hash return value: starts with '0x' and only contains hexadecimal values
-        expect(did_hash.startsWith('0x')).toBe(true);
-        expect(/^0x[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
+        // check did hash return value: only contains hexadecimal values
+        expect(/^[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
       });
 
       it('generate did Substrate address', async () => {
         const result = await SDK.generateDidDocument({address: user.address});
         const did_hash = result.value;
-        // check did hash return value: starts with '0x' and only contains hexadecimal values
-        expect(did_hash.startsWith('0x')).toBe(true);
-        expect(/^0x[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
+        // check did hash return value: only contains hexadecimal values
+        expect(/^[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
 
         // convert the did hash into a readable did document to check the default values
         const document = peaqDidProto.Document.deserializeBinary(hexToU8a(result?.value));
@@ -123,9 +121,8 @@ describe('Did', () => {
         const addressETH = '0x9Eeab1aCcb1A701aEfAB00F3b8a275a39646641C';
         const result = await SDK.generateDidDocument({address: addressETH, customDocumentFields: {controller: addressETH}});
         const did_hash = result.value;
-        // check did hash return value: starts with '0x' and only contains hexadecimal values
-        expect(did_hash.startsWith('0x')).toBe(true);
-        expect(/^0x[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
+        // check did hash return value: only contains hexadecimal values
+        expect(/^[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
 
         // convert the did hash into a readable did document to check the default values
         const document = peaqDidProto.Document.deserializeBinary(hexToU8a(result?.value));
@@ -155,9 +152,8 @@ describe('Did', () => {
 
         const result = await SDK.generateDidDocument({address: user.address, customDocumentFields: customFields});
         const did_hash = result.value;
-        // check did hash return value: starts with '0x' and only contains hexadecimal values
-        expect(did_hash.startsWith('0x')).toBe(true);
-        expect(/^0x[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
+        // check did hash return value: only contains hexadecimal values
+        expect(/^[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
 
         // convert the did hash into a readable did document to check the default values
         const document = peaqDidProto.Document.deserializeBinary(hexToU8a(result?.value));
@@ -188,9 +184,8 @@ describe('Did', () => {
 
         const result = await SDK.generateDidDocument({address: addressETH, customDocumentFields: customFields});
         const did_hash = result.value;
-        // check did hash return value: starts with '0x' and only contains hexadecimal values
-        expect(did_hash.startsWith('0x')).toBe(true);
-        expect(/^0x[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
+        // check did hash return value: only contains hexadecimal values
+        expect(/^[a-fA-F0-9]+$/.test(did_hash)).toBe(true);
 
         // convert the did hash into a readable did document to check the default values
         const document = peaqDidProto.Document.deserializeBinary(hexToU8a(result?.value));
@@ -454,7 +449,7 @@ describe('Did', () => {
     });
 
     it('read a known did with address and proper name passed', async () => {
-      const known_did  = 'did-test';
+      const known_did  = 'did-test-123';
 
       const read_did = await sdk.did.read({name: known_did, address: user.address}) ;
       expect(read_did).toBeDefined();
@@ -976,7 +971,7 @@ async function readDid(read_did: ReadDidResponse, new_did: string, user: Keyring
   expect(read_did?.value).toBeDefined();
 
   // value names based on expected regex formats
-  const valuePattern = /^0x[0-9a-fA-F]+$/;
+  const valuePattern = /^[0-9a-fA-F]+$/;
   const validityPattern = /^\d{1,3}(,\d{3})*$/;
   const createdPattern = /^\d{1,3}(,\d{3})*$/;
   

--- a/packages/sdk/src/modules/did/index.ts
+++ b/packages/sdk/src/modules/did/index.ts
@@ -2,7 +2,7 @@ import * as peaqDidProto from 'peaq-did-proto-js';
 import { Attribute } from '@peaq-network/types/interfaces';
 import { ApiPromise } from '@polkadot/api';
 import { decodeAddress } from '@polkadot/util-crypto';
-import { u8aToHex } from '@polkadot/util';
+import { u8aToHex, hexToU8a } from '@polkadot/util';
 import type { CodecHash } from '@polkadot/types/interfaces/runtime/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
@@ -234,7 +234,8 @@ export class Did extends Base {
 
       if (!did || did.isStorageFallback) return null;
 
-      const document = peaqDidProto.Document.deserializeBinary(did?.value);
+      const didValue = String(did.toHuman()['value']);
+      const document = peaqDidProto.Document.deserializeBinary(hexToU8a(didValue));
 
       return {
         ...did.toHuman(),
@@ -432,7 +433,7 @@ export class Did extends Base {
     return documentService;
   }
 
- private _generateDidDocument(options: DidDocumentOptions): `0x${string}` {
+ private _generateDidDocument(options: DidDocumentOptions): string {
     const { didAccountAddress, didControllerAddress, customDocumentFields } = options;
 
     let document = new peaqDidProto.Document();
@@ -480,10 +481,14 @@ export class Did extends Base {
     }
 
     const bytes = document.serializeBinary();
-    return u8aToHex(bytes);
+    const hexString = u8aToHex(bytes);
+
+    // remove '0x' prefix if present
+    const hash = hexString.startsWith('0x') ? hexString.slice(2) : hexString;
+    return hash;
   }
 
-  private _updateDidDocument(options: UpdateDidDocumentOptions): `0x${string}` {
+  private _updateDidDocument(options: UpdateDidDocumentOptions): string {
     const { didAccountAddress, didControllerAddress, customDocumentFields, oldDocument } = options;
     
     let newDocument = new peaqDidProto.Document();
@@ -544,7 +549,11 @@ export class Did extends Base {
     }
 
     const bytes = newDocument.serializeBinary();
-    return u8aToHex(bytes);
+    const hexString = u8aToHex(bytes);
+
+    // remove '0x' prefix if present
+    const hash = hexString.startsWith('0x') ? hexString.slice(2) : hexString;
+    return hash;
   }
 
   private _setController(customDocumentFields: UpdateDocumentFields, newDocument: peaqDidProto.Document){

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/types",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "Apache-2.0",
   "description": "Typescript definitions for the peaq network",
   "repository": {


### PR DESCRIPTION
There was an issue with the recently changes made to the rust backend that cased DID Document hashes that started with '0x' to give a **AttributeNonAsciiProperty** error. This update removes this prefix before storing the hash on-chain to prevent these errors. Also updated the read logic to display the DID Document from the hash that is stored at the value.