### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peaq-js
 
-Follow [documentation](https://docs.peaq.network/sdk) for a detailed overview of the features and functionalities of peaq SDK.
+Follow [documentation](https://docs.peaq.network/docs/build/sdk/) for a detailed overview of the features and functionalities of peaq SDK.
 
 
 ## Edit functions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peaq-js
 
-Follow [documentation](https://docs.peaq.network/docs/build/sdk/) for a detailed overview of the features and functionalities of peaq SDK.
+Follow [documentation](https://docs.peaq.network/docs/build/sdk/sdk-installation/) for a detailed overview of the features and functionalities of peaq SDK.
 
 
 ## Edit functions


### PR DESCRIPTION
This README.md discusses the peaq JavaScript SDK, yet the  documentation URL links to the the top level documentation (https://docs.peaq.network/docs/quick-start/what-is-peaq/) where there is no mention of any SDK on either the main page or in the left side navigation menu.

A more appropriate link would be the documentation page that is about the JavaScript SDK:  https://docs.peaq.network/docs/build/sdk/sdk-installation/