### PR TITLE
ECO-48 Update item accepts objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peaq-network",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peaq-network",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@polkadot/api": "12.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peaq-network",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "scripts": {
     "prepare": "ts-patch install -s"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "peaq network sdk",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk/src/modules/storage/evm_class_storage.ts
+++ b/packages/sdk/src/modules/storage/evm_class_storage.ts
@@ -25,34 +25,6 @@ enum PrecompileAddresses {
     STORAGE = "0x0000000000000000000000000000000000000801"
 }
 
-// interface AddItemOptions {
-//     itemType: string;
-//     item: string;
-// }
-
-// type RemoveItemOptions = {
-//     itemType: string;
-// }
-
-// type GetItemOptions = {
-//     itemType: string;
-//     address: string;
-//     wssBaseUrl: string;
-// }
-
-// type GetItemResult = {
-//     [key: string]: string;
-// }
-
-// type UpdateItemOptions = {
-//     itemType: string;
-//     item: string;
-// }
-
-// export interface EvmTransaction {
-//     to: string;
-//     data: string;
-// }
 
 /**
  * Class that builds peaq's Storage EVM transactions.
@@ -145,7 +117,8 @@ export class StorageClassEvm {
         const createStorageFunctionSelector = ethers.keccak256(ethers.toUtf8Bytes(FunctionSignatures.UPDATE_ITEM)).substring(0, 10);
 
         const itemTypeBytes = ethers.hexlify(ethers.toUtf8Bytes(itemType));
-        const itemBytes = ethers.hexlify(ethers.toUtf8Bytes(item));
+        const itemString = typeof item === 'string' ? item : JSON.stringify(item);
+        const itemBytes = ethers.hexlify(ethers.toUtf8Bytes(itemString));
 
         const params = this.abiCoder.encode(
             ["bytes", "bytes"],

--- a/packages/sdk/src/modules/storage/index.ts
+++ b/packages/sdk/src/modules/storage/index.ts
@@ -174,21 +174,21 @@ export class Storage extends Base {
             if (!itemType) throw new ItemTypeError('Item Type name is required');
             if (!item) throw new ItemError('Item name is required');
             if (seed !== '') this._checkSeed(seed);
-            // convert string to bytes to count before calling extrinsics
+            const itemString = typeof item === 'string' ? item : JSON.stringify(item);
             if (stringToU8a(itemType).length > 64) throw new ItemTypeError('New Item Type cannot be larger than 64 bytes');
-            if (stringToU8a(item).length > 256) throw new ItemError('New Item cannot be larger than 256 bytes');
+            if (stringToU8a(itemString).length > 256) throw new ItemError('New Item cannot be larger than 256 bytes');
     
              // EVM tx logic if chainType is set to EVM
             if (this._metadata?.chainType == ChainType.EVM) {
                 const evm = new StorageClassEvm();
-                return await evm.updateItem({itemType: itemType,  item: item})
+                return await evm.updateItem({itemType: itemType,  item: itemString})
             }
 
             const api = this._getApi();
             const keyPair = this._metadata?.pair || this._getKeyPair(seed);
             const attributeExtrinsic = api.tx?.['peaqStorage']?.['updateItem'](
                 itemType,
-                item
+                itemString
             );
             const nonce = await this._getNonce(keyPair.address);
             const eventData = await this._newSignTx({nonce, address: keyPair, extrinsics: attributeExtrinsic});
@@ -198,7 +198,7 @@ export class Storage extends Base {
             });
             // is it necessary to add more verbose logging in return object?
             return {
-                message: `Successfully updated the storage item type ${itemType} to the new item ${item} for the address ${keyPair.address}`,
+                message: `Successfully updated the storage item type ${itemType} to the new item ${itemString} for the address ${keyPair.address}`,
                 block_hash: eventData[0]?.blockHash as unknown as CodecHash,
                 unsubscribe,
             };

--- a/packages/sdk/src/modules/storage/interface.ts
+++ b/packages/sdk/src/modules/storage/interface.ts
@@ -21,7 +21,7 @@ export interface GetItemOptions {
 
 export interface UpdateItemOptions {
     itemType: string;
-    item: string;
+    item: Object;
     seed?: string;
 }
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "author": "peaq network <info@peaq.io>",
   "name": "@peaq-network/types",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "Apache-2.0",
   "description": "Typescript definitions for the peaq network",
   "repository": {


### PR DESCRIPTION
Allowed for the update item extrinsic in EVM or Substrate calls to our blockchain to accepts objects, rather than just strings.